### PR TITLE
Cs other review changes

### DIFF
--- a/src/DssKiln.sol
+++ b/src/DssKiln.sol
@@ -78,7 +78,7 @@ abstract contract DssKiln {
     }
 
     /**
-        @dev (Required)
+        @dev Auth'ed function to update lot or hop values
         @param what   Tag of value to update
         @param data   Value to update
     */

--- a/src/DssKiln.sol
+++ b/src/DssKiln.sol
@@ -83,8 +83,8 @@ abstract contract DssKiln {
         @param data   Value to update
     */
     function file(bytes32 what, uint256 data) external auth {
-        if      (what == "lot")         lot = data;
-        else if (what == "hop")         hop = data;
+        if      (what == "lot") lot = data;
+        else if (what == "hop") hop = data;
         else revert("DssKiln/file-unrecognized-param");
         emit File(what, data);
     }

--- a/src/DssKiln.sol
+++ b/src/DssKiln.sol
@@ -92,6 +92,9 @@ abstract contract DssKiln {
         emit File(what, data);
     }
 
+    /**
+        @dev Function to execute swap/drop and reset zzz if enough time has passed
+    */
     function fire() external lock {
         require(block.timestamp >= _add(zzz, hop), "DssKiln/fired-too-soon");
         uint256 _amt = _min(GemLike(sell).balanceOf(address(this)), lot);

--- a/src/DssKiln.sol
+++ b/src/DssKiln.sol
@@ -30,41 +30,19 @@ abstract contract DssKiln {
 
     // --- Auth ---
     mapping (address => uint256) public wards;
-    function rely(address usr) external auth { wards[usr] = 1; emit Rely(usr); }
-    function deny(address usr) external auth { wards[usr] = 0; emit Deny(usr); }
-    modifier auth {
-        require(wards[msg.sender] == 1, "DssKiln/not-authorized");
-        _;
-    }
 
-    uint256 public lot;  // [WAD]        Amount of token to sell
-    uint256 public hop;  // [Seconds]    Time between sales
-    uint256 public zzz;  // [Timestamp]  Last trade
-
+    uint256 public           lot;  // [WAD]        Amount of token to sell
+    uint256 public           hop;  // [Seconds]    Time between sales
+    uint256 public           zzz;  // [Timestamp]  Last trade
     address public immutable sell;
     address public immutable buy;
 
-    // --- Mutex  ---
     uint256 internal locked;
-    modifier lock {
-        require(locked == 0, "DssKiln/system-locked");
-        locked = 1;
-        _;
-        locked = 0;
-    }
 
     event Rely(address indexed usr);
     event Deny(address indexed usr);
     event File(bytes32 indexed what, uint256 data);
     event Fire(uint256 indexed dai, uint256 indexed mkr);
-
-    function _add(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        require((z = x + y) >= x);
-    }
-
-    function _min(uint256 x, uint256 y) internal pure returns (uint z) {
-        return x <= y ? x : y;
-    }
 
     /**
         @dev Base contract constructor
@@ -76,6 +54,31 @@ abstract contract DssKiln {
         wards[msg.sender] = 1;
         emit Rely(msg.sender);
     }
+
+    modifier auth {
+        require(wards[msg.sender] == 1, "DssKiln/not-authorized");
+        _;
+    }
+
+    // --- Mutex  ---
+    modifier lock {
+        require(locked == 0, "DssKiln/system-locked");
+        locked = 1;
+        _;
+        locked = 0;
+    }
+
+    function _add(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require((z = x + y) >= x);
+    }
+
+    function _min(uint256 x, uint256 y) internal pure returns (uint z) {
+        return x <= y ? x : y;
+    }
+
+    function rely(address usr) external auth { wards[usr] = 1; emit Rely(usr); }
+
+    function deny(address usr) external auth { wards[usr] = 0; emit Deny(usr); }
 
     /**
         @dev Auth'ed function to update lot or hop values

--- a/src/DssKiln.sol
+++ b/src/DssKiln.sol
@@ -82,7 +82,7 @@ abstract contract DssKiln {
         @param what   Tag of value to update
         @param data   Value to update
     */
-    function file(bytes32 what, uint256 data) external auth lock {
+    function file(bytes32 what, uint256 data) external auth {
         if      (what == "lot")         lot = data;
         else if (what == "hop")         hop = data;
         else revert("DssKiln/file-unrecognized-param");


### PR DESCRIPTION
Collection of other changes I thought could help DSS-Kiln:

- no lock on file function since it doesn't have external calls (928eeab727fe93c581f17a2691dfe5b32551d3d4)
- remove extra spacing (a643ac9e4fda71f0ba65eaa3079c1dcada29a3d5)
- update natspec on file (c1f185d1bfbb0d554bae5af4fc98219117d24be4)
- reordered based on what we discussed in D3M (storage -> events -> constructor -> modifiers -> internal -> external) (c6f2f82699bb1ef77377cfd9ff2c0a6490689133)
- add natspec for fire (09d5016047971f43e35f30673ad72bebc7910aad)