### PR TITLE
Review Changes

### DIFF
--- a/src/KilnBase.sol
+++ b/src/KilnBase.sol
@@ -91,6 +91,7 @@ abstract contract KilnBase {
         @param dst   Destination of the funds
     */
     function rug(address dst) external auth lock {
+        require(dst != address(this), "KilnBase/invalid-dst");
         uint256 amt = GemLike(sell).balanceOf(address(this));
         GemLike(sell).transfer(dst, amt);
         emit Rug(dst, amt);

--- a/src/KilnBase.sol
+++ b/src/KilnBase.sol
@@ -17,7 +17,6 @@
 pragma solidity ^0.8.14;
 
 interface GemLike {
-    function approve(address, uint256) external;
     function balanceOf(address) external view returns (uint256);
     function transfer(address, uint256) external;
 }

--- a/src/KilnBase.sol
+++ b/src/KilnBase.sol
@@ -99,7 +99,7 @@ abstract contract KilnBase {
         @param dst   Destination of the funds
     */
     function _rug(address dst) internal lock {
-        require(dst != address(this), "KilnBase/invalid-dst");
+        require(dst != address(0) && dst != address(this), "KilnBase/invalid-dst");
         uint256 amt = GemLike(sell).balanceOf(address(this));
         GemLike(sell).transfer(dst, amt);
         emit Rug(dst, amt);

--- a/src/KilnBase.sol
+++ b/src/KilnBase.sol
@@ -90,7 +90,15 @@ abstract contract KilnBase {
         @dev Auth'ed function to withdraw unspent funds
         @param dst   Destination of the funds
     */
-    function rug(address dst) external auth lock {
+    function rug(address dst) external auth {
+        _rug(dst);
+    }
+
+    /**
+        @dev Internal logic to withdraw unspent funds
+        @param dst   Destination of the funds
+    */
+    function _rug(address dst) internal lock {
         require(dst != address(this), "KilnBase/invalid-dst");
         uint256 amt = GemLike(sell).balanceOf(address(this));
         GemLike(sell).transfer(dst, amt);

--- a/src/KilnBase.t.sol
+++ b/src/KilnBase.t.sol
@@ -145,6 +145,11 @@ contract KilnBaseTest is Test {
         kiln.rug(address(this));
     }
 
+    function testRugInvalidDst() public {
+        vm.expectRevert("KilnBase/invalid-dst");
+        kiln.rug(address(kiln));
+    }
+
     function testFire() public {
         mintDai(address(kiln), 50_000 * WAD);
         vm.expectEmit(true, true, false, false);

--- a/src/KilnBase.t.sol
+++ b/src/KilnBase.t.sol
@@ -145,9 +145,14 @@ contract KilnBaseTest is Test {
         kiln.rug(address(this));
     }
 
-    function testRugInvalidDst() public {
+    function testRugInvalidDstContractAddress() public {
         vm.expectRevert("KilnBase/invalid-dst");
         kiln.rug(address(kiln));
+    }
+
+    function testRugInvalidDstZeroAddress() public {
+        vm.expectRevert("KilnBase/invalid-dst");
+        kiln.rug(address(0));
     }
 
     function testFire() public {

--- a/src/KilnMom.sol
+++ b/src/KilnMom.sol
@@ -24,16 +24,11 @@ interface AuthorityLike {
     function canCall(address src, address dst, bytes4 sig) external view returns (bool);
 }
 
-interface VatLike {
-    function live() external view returns (uint256);
-}
-
 // Bypass governance delay to disable a kiln instance
 contract KilnMom {
     address public owner;
     address public authority;
 
-    address public immutable vat;
     address public immutable dst;
 
     event SetOwner(address indexed newOwner);
@@ -45,10 +40,14 @@ contract KilnMom {
         _;
     }
 
-    constructor(address _vat, address _dst) {
-        vat = _vat;
+    modifier auth {
+        require(isAuthorized(msg.sender, msg.sig), "KilnMom/not-authorized");
+        _;
+    }
+
+    constructor(address _dst) {
         dst = _dst;
-        
+
         owner = msg.sender;
         emit SetOwner(msg.sender);
     }
@@ -77,12 +76,7 @@ contract KilnMom {
     }
 
     // Governance action without delay
-    function rug(address who) external {
-        require(
-            isAuthorized(msg.sender, msg.sig) || VatLike(vat).live() == 0,
-            "KilnMom/not-authorized"
-        );
-
+    function rug(address who) external auth {
         address _dst = dst;
         RugLike(who).rug(_dst);
         emit Rug(who, _dst);

--- a/src/KilnMom.sol
+++ b/src/KilnMom.sol
@@ -46,6 +46,7 @@ contract KilnMom {
     }
 
     constructor(address _dst) {
+        require(_dst != address(0), "KilnMom/invalid-dst");
         dst = _dst;
 
         owner = msg.sender;

--- a/src/KilnMom.t.sol
+++ b/src/KilnMom.t.sol
@@ -58,6 +58,11 @@ contract KilnMomTest is Test {
         kiln.rely(address(mom));
     }
 
+    function testDeployWithDstZeroAddress() public {
+        vm.expectRevert("KilnMom/invalid-dst");
+        new KilnMom(address(0));
+    }
+
     function mintDai(address usr, uint256 amt) internal {
         deal(DAI, usr, amt);
         assertEq(GemLike(DAI).balanceOf(address(usr)), amt);

--- a/src/KilnMom.t.sol
+++ b/src/KilnMom.t.sol
@@ -34,17 +34,12 @@ contract AuthorityMock {
     }
 }
 
-interface VatLike {
-    function cage() external;
-}
-
 contract KilnMomTest is Test {
     KilnMock kiln;
     KilnMom mom;
 
     address constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
     address constant MKR = 0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2;
-    address constant VAT = 0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B;
 
     uint256 constant WAD = 1e18;
 
@@ -58,7 +53,7 @@ contract KilnMomTest is Test {
         kiln.file("lot", 50_000 * WAD);
         kiln.file("hop", 6 hours);
 
-        mom = new KilnMom(VAT, address(this));
+        mom = new KilnMom(address(this));
         mom.setAuthority(address(new AuthorityMock()));
         kiln.rely(address(mom));
     }
@@ -117,26 +112,6 @@ contract KilnMomTest is Test {
 
         vm.prank(address(789));
         vm.expectEmit(true, false, false, false);
-        emit Rug(address(kiln), address(this));
-        mom.rug(address(kiln));
-
-        assertEq(GemLike(DAI).balanceOf(address(kiln)), 0);
-        assertEq(GemLike(DAI).balanceOf(address(mom)), 0);
-        assertEq(GemLike(DAI).balanceOf(address(this)), 50_000 * WAD);
-    }
-
-    function testRugVatNotLive() public {
-        mintDai(address(kiln), 50_000 * WAD);
-
-        assertEq(kiln.sell(), DAI);
-        assertEq(GemLike(DAI).balanceOf(address(kiln)), 50_000 * WAD);
-
-        // become Vat owner and cage it
-        vm.store(VAT, keccak256(abi.encode(address(this), uint256(0))), bytes32(uint256(1)));
-        VatLike(VAT).cage();
-
-        vm.startPrank(address(456));
-        vm.expectEmit(true, true, false, false);
         emit Rug(address(kiln), address(this));
         mom.rug(address(kiln));
 

--- a/src/KilnUniV3.sol
+++ b/src/KilnUniV3.sol
@@ -19,9 +19,8 @@ pragma solidity ^0.8.14;
 import {KilnBase} from "./KilnBase.sol";
 import {TwapProduct}       from "./uniV3/TwapProduct.sol";
 
-interface GemLike {
+interface TokenLike {
     function approve(address, uint256) external;
-    function balanceOf(address) external view returns (uint256);
 }
 
 interface VatLike {
@@ -134,7 +133,7 @@ contract KilnUniV3 is KilnBase, TwapProduct {
     }
 
     function _swap(uint256 amount) internal override returns (uint256 swapped) {
-        GemLike(sell).approve(uniV3Router, amount);
+        TokenLike(sell).approve(uniV3Router, amount);
 
         bytes   memory _path = path;
         uint256        _yen  = yen;

--- a/src/KilnUniV3.sol
+++ b/src/KilnUniV3.sol
@@ -16,8 +16,13 @@
 
 pragma solidity ^0.8.14;
 
-import {KilnBase, GemLike} from "./KilnBase.sol";
+import {KilnBase} from "./KilnBase.sol";
 import {TwapProduct}       from "./uniV3/TwapProduct.sol";
+
+interface GemLike {
+    function approve(address, uint256) external;
+    function balanceOf(address) external view returns (uint256);
+}
 
 // https://github.com/Uniswap/v3-periphery/blob/b06959dd01f5999aa93e1dc530fe573c7bb295f6/contracts/SwapRouter.sol
 interface SwapRouterLike {
@@ -46,7 +51,7 @@ contract KilnUniV3 is KilnBase, TwapProduct {
     event File(bytes32 indexed what, bytes data);
 
     // @notice initialize a Uniswap V3 routing path contract
-    // @dev TWAP-relative trading is enabled by default. With the initial values, fire will 
+    // @dev TWAP-relative trading is enabled by default. With the initial values, fire will
     //      perform the trade only when the amount of tokens received is equal or better than
     //      the 1 hour average price.
     // @param _sell          the contract address of the token that will be sold

--- a/src/KilnUniV3.sol
+++ b/src/KilnUniV3.sol
@@ -24,6 +24,10 @@ interface GemLike {
     function balanceOf(address) external view returns (uint256);
 }
 
+interface VatLike {
+    function live() external view returns (uint256);
+}
+
 // https://github.com/Uniswap/v3-periphery/blob/b06959dd01f5999aa93e1dc530fe573c7bb295f6/contracts/SwapRouter.sol
 interface SwapRouterLike {
     function exactInput(ExactInputParams calldata params) external returns (uint256 amountOut);
@@ -44,10 +48,13 @@ contract KilnUniV3 is KilnBase, TwapProduct {
     uint256 public scope; // [Seconds]  Time period for TWAP calculations
     uint256 public yen;   // [WAD]      Relative multiplier of the TWAP's price to insist on
     bytes   public path;  //            ABI-encoded UniV3 compatible path
+    address public dst;   //            Destination address to withdraw unspent funds permissionless during GS
 
+    address public immutable vat;
     address public immutable uniV3Router;
     address public immutable receiver;
 
+    event File(bytes32 indexed what, address data);
     event File(bytes32 indexed what, bytes data);
 
     // @notice initialize a Uniswap V3 routing path contract
@@ -59,6 +66,7 @@ contract KilnUniV3 is KilnBase, TwapProduct {
     // @param _uniV3Router   the address of the current Uniswap V3 swap router
     // @param _receiver      the address of the account which will receive the funds to be bought
     constructor(
+        address _vat,
         address _sell,
         address _buy,
         address _uniV3Router,
@@ -67,6 +75,7 @@ contract KilnUniV3 is KilnBase, TwapProduct {
         KilnBase(_sell, _buy)
         TwapProduct(SwapRouterLike(_uniV3Router).factory())
     {
+        vat = _vat;
         uniV3Router = _uniV3Router;
         receiver    = _receiver;
 
@@ -75,6 +84,17 @@ contract KilnUniV3 is KilnBase, TwapProduct {
     }
 
     uint256 constant WAD = 10 ** 18;
+
+    /**
+        @dev Auth'ed function to update dst value
+        @param what   Tag of value to update
+        @param data   Value to update
+    */
+    function file(bytes32 what, address data) external auth {
+        if (what == "dst") dst = data;
+        else revert("KilnUniV3/file-unrecognized-param");
+        emit File(what, data);
+    }
 
     /**
         @dev Auth'ed function to update path value
@@ -105,6 +125,12 @@ contract KilnUniV3 is KilnBase, TwapProduct {
             return;
         }
         emit File(what, data);
+    }
+
+    function rug() external {
+        require(VatLike(vat).live() == 0,"KilnUniV3/vat-live");
+        address _dst = dst;
+        _rug(_dst);
     }
 
     function _swap(uint256 amount) internal override returns (uint256 swapped) {

--- a/src/KilnUniV3.t.sol
+++ b/src/KilnUniV3.t.sol
@@ -188,6 +188,23 @@ contract KilnTest is Test {
         assertEq(TestGem(DAI).balanceOf(address(this)), 50_000 * WAD);
     }
 
+    function testRugVatLive() public {
+        vm.expectRevert("KilnUniV3/vat-live");
+        kiln.rug();
+    }
+
+    function testRugInvalidDstContractAddress() public {
+        kiln.file("dst", address(this));
+        vm.expectRevert("KilnBase/invalid-dst");
+        kiln.rug(address(kiln));
+    }
+
+    function testRugInvalidDstZeroAddress() public {
+        kiln.file("dst", address(0));
+        vm.expectRevert("KilnBase/invalid-dst");
+        kiln.rug(address(0));
+    }
+
     function testFireYenMuchLessThanTwap() public {
         mintDai(address(kiln), 50_000 * WAD);
 

--- a/src/KilnUniV3.t.sol
+++ b/src/KilnUniV3.t.sol
@@ -63,7 +63,7 @@ contract KilnTest is Test {
     event File(bytes32 indexed what, bytes data);
     event File(bytes32 indexed what, uint256 data);
 
-    event Rug(address indexed dst, uint256 indexed amt);
+    event Rug(address indexed dst, uint256 amt);
 
     function setUp() public {
         user = new User();
@@ -180,7 +180,8 @@ contract KilnTest is Test {
         vm.store(VAT, keccak256(abi.encode(address(this), uint256(0))), bytes32(uint256(1)));
         TestVat(VAT).cage();
 
-        emit Rug(address(kiln), 50_000 * WAD);
+        vm.expectEmit(true, true, false, false);
+        emit Rug(address(this), 50_000 * WAD);
         kiln.rug();
 
         assertEq(TestGem(DAI).balanceOf(address(kiln)), 0);


### PR DESCRIPTION
Minor Changes following Certora Specs and general code inspection:
- [x] unused `approve` in `KilnBase.sol`
- [x] `rug` sanity check for `address(this)`
- [x] open discussion to keep Mom pattern consistent and separate permissionless component based on specific kiln implementations, by extrapolating the logic into an internal function in KilnBase, and adopting overloaded functions, an authed one for the KilnMom in KilnBase and a permissionless one in KilnUniV3 (with a `vat.live` check).
- [x] `rug` sanity checks for `address(o)`
- [x] refactoring & cleanups
 